### PR TITLE
gmscompat: Fix permission denial for GCM broadcasts

### DIFF
--- a/core/java/android/app/ContextImpl.java
+++ b/core/java/android/app/ContextImpl.java
@@ -1222,6 +1222,8 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastMultiplePermissions(Intent intent, String[] receiverPermissions,
             Bundle options) {
+        options = GmsHooks.filterBroadcastOptions(options);
+
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         try {
@@ -1270,6 +1272,8 @@ class ContextImpl extends Context {
 
     @Override
     public void sendBroadcast(Intent intent, String receiverPermission, Bundle options) {
+        options = GmsHooks.filterBroadcastOptions(options);
+
         warnIfCallingFromSystemProcess();
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
         String[] receiverPermissions = receiverPermission == null ? null
@@ -1352,6 +1356,8 @@ class ContextImpl extends Context {
             String receiverPermission, int appOp, BroadcastReceiver resultReceiver,
             Handler scheduler, int initialCode, String initialData,
             Bundle initialExtras, Bundle options) {
+        options = GmsHooks.filterBroadcastOptions(options);
+
         warnIfCallingFromSystemProcess();
         IIntentReceiver rd = null;
         if (resultReceiver != null) {
@@ -1409,6 +1415,7 @@ class ContextImpl extends Context {
     @Override
     public void sendBroadcastAsUser(Intent intent, UserHandle user, String receiverPermission,
             Bundle options) {
+        options = GmsHooks.filterBroadcastOptions(options);
         user = GmsHooks.getUserHandle(user);
 
         String resolvedType = intent.resolveTypeIfNeeded(getContentResolver());
@@ -1465,6 +1472,7 @@ class ContextImpl extends Context {
     public void sendOrderedBroadcastAsUser(Intent intent, UserHandle user,
             String receiverPermission, int appOp, Bundle options, BroadcastReceiver resultReceiver,
             Handler scheduler, int initialCode, String initialData, Bundle initialExtras) {
+        options = GmsHooks.filterBroadcastOptions(options);
         user = GmsHooks.getUserHandle(user);
 
         IIntentReceiver rd = null;


### PR DESCRIPTION
When sending GCM broadcasts, GMS will try to grant temporary power
management exemption to the recipient app. This triggers a
SecurityException and crashes the calling process.

> java.lang.SecurityException: Permission Denial:
> com.google.android.c2dm.intent.RECEIVE broadcast from
> com.google.android.gms (pid=21608, uid=1010132) requires
> android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST or
> android.permission.START_ACTIVITIES_FROM_BACKGROUND or
> android.permission.START_FOREGROUND_SERVICES_FROM_BACKGROUND

Fix this by clearing the exemptions from the broadcast options.

Change-Id: Ie6c60c56350261409233411f2f85d0c9a6d08546